### PR TITLE
Update deps and fix badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## meta-remarkable
 #### The [remarkable](https://github.com/jonschlinkert/remarkable) markdown processor for Node.js with support for [YAML](http://yaml.org/) metadata
 
-![dependencies](http://img.shields.io/david/bmathews/meta-remarkable.svg?style=flat-square)
+[![Dependency Status](https://david-dm.org/bmathews/meta-remarkable.svg)](https://david-dm.org/bmathews/meta-remarkable)
 
 The render function behaves exactly the same as [`remarkable`](https://github.com/jonschlinkert/remarkable#usage), except it instead returns an object with two properties: `meta`, which contains the metadata object or `null` if metadata isn't found, and `html`, which contains the parsed HTML.
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "url": "git://github.com/bmathews/meta-remarkable.git"
   },
   "dependencies": {
-    "js-yaml": "~3.2.2",
-    "remarkable": "^1.3.0"
+    "js-yaml": "3.3.0",
+    "remarkable": "1.6.0"
   },
   "devDependencies": {
     "tape": "~3.0.0"


### PR DESCRIPTION
- Updates the deps to the latest versions - should fix the insecure deps warning.
- Update the README deps badge to link to david.
